### PR TITLE
fix: remove duplicate Range interface (DRY violation)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,8 +1,3 @@
-export interface Range {
-        min: number;
-        max: number;
-}
-
 export interface Model {
         id: string;
         name: string;


### PR DESCRIPTION
## Summary
DRY (Don't Repeat Yourself) 원칙 위반 수정

## 문제
`Range` 인터페이스가 두 곳에 중복 정의되어 있었음:
- `src/api/types.ts:1-4`
- `src/frontmatter/types.ts:5-8`

## 해결
- `api/types.ts`의 `Range`는 실제로 사용되지 않음
- `frontmatter/types.ts`의 `Range`만 `FrontmatterField.count`에서 사용
- 사용되지 않는 `api/types.ts`의 중복 정의 제거

## DRY 원칙이란?
> "Every piece of knowledge must have a single, unambiguous representation"

같은 코드/정의가 여러 곳에 있으면:
- 한 곳만 수정하고 다른 곳을 잊어버릴 위험
- 시간이 지나며 정의가 서로 달라질 수 있음
- 어떤 것이 "진짜"인지 혼란

## Test Results
- Build: ✅ Pass