### PR TITLE
fix: remove unused OPENROUTER_STRUCTURE_OUTPUT (DRY)

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -74,16 +74,6 @@ export const OPENAI_STRUCTURE_OUTPUT = {
 	},
 };
 
-// OpenRouter Configuration
-export const OPENROUTER_STRUCTURE_OUTPUT = {
-	type: 'json_schema',
-	json_schema: {
-		name: 'metadata_classifier',
-		schema: COMMON_SCHEMA_BASE,
-		strict: true,
-	},
-};
-
 // LMStudio Configuration
 export const LMSTUDIO_STRUCTURE_OUTPUT = {
 	type: 'json_schema',


### PR DESCRIPTION
## Summary
DRY 원칙 위반 수정 - 사용되지 않는 중복 상수 제거

## 문제
```typescript
// 두 상수가 완전히 동일
export const OPENAI_STRUCTURE_OUTPUT = {
    type: 'json_schema',
    json_schema: { name: 'metadata_classifier', schema: COMMON_SCHEMA_BASE, strict: true },
};

export const OPENROUTER_STRUCTURE_OUTPUT = {
    type: 'json_schema', 
    json_schema: { name: 'metadata_classifier', schema: COMMON_SCHEMA_BASE, strict: true },
};
```

## 분석
- `OPENAI_STRUCTURE_OUTPUT`: UnifiedProvider.ts에서 OpenRouter, Default spec 모두에서 사용
- `OPENROUTER_STRUCTURE_OUTPUT`: 정의만 있고 **어디서도 사용되지 않음**

## 해결
사용되지 않는 `OPENROUTER_STRUCTURE_OUTPUT` 제거

## Dead Code는 왜 문제인가?
- 코드 읽는 사람이 "이건 어디서 쓰이지?" 혼란
- 나중에 수정할 때 "이것도 바꿔야 하나?" 고민 유발
- 번들 크기 불필요하게 증가 (tree shaking이 안 되는 경우)

## Test Results
- Build: ✅ Pass