### PR TITLE
fix: use actual settings instead of constant in Tag.ts

### DIFF
--- a/src/ui/containers/Tag.ts
+++ b/src/ui/containers/Tag.ts
@@ -1,7 +1,6 @@
 import type { FrontmatterField } from 'frontmatter/types';
 import { BaseSettingsComponent } from 'ui/components/BaseSettings';
 import type { FrontmatterActions, SettingsComponentOptions } from 'ui/types';
-import { DEFAULT_TAG_SETTING } from '../../utils/constants';
 
 export class Tag extends BaseSettingsComponent {
 	protected readonly options: SettingsComponentOptions = {
@@ -11,12 +10,19 @@ export class Tag extends BaseSettingsComponent {
 	};
 
 	display(): void {
+		this.containerEl.empty();
+
+		const tagSetting = this.plugin.settings.frontmatter.find((f) => f.id === 0);
+		if (!tagSetting) {
+			return;
+		}
+
                 const actions: FrontmatterActions = {
                         onEdit: (setting: FrontmatterField) => this.handleEdit(setting),
 			onDelete: () => {},
 		};
 
-		this.createFrontmatterSetting(this.containerEl, DEFAULT_TAG_SETTING, actions, false);
+		this.createFrontmatterSetting(this.containerEl, tagSetting, actions, false);
 	}
 
         private handleEdit(frontmatterSetting: FrontmatterField): void {


### PR DESCRIPTION
## Summary
Tag 컴포넌트가 실제 설정값 대신 상수를 사용하던 버그 수정

## 문제
```typescript
// Before - 항상 기본값을 보여줌
display(): void {
    this.createFrontmatterSetting(this.containerEl, DEFAULT_TAG_SETTING, actions, false);
    //                                              ^^^^^^^^^^^^^^^^^^^
    //                                              상수! 사용자 설정 무시
}
```

### 버그 시나리오
1. 사용자가 Tag 설정에서 count를 `1-5`에서 `2-10`으로 변경
2. 저장됨 (`handleEdit`에서 `plugin.settings`에 저장)
3. 설정 탭을 다시 열면... **여전히 `1-5`로 표시됨**
4. 왜? UI가 `DEFAULT_TAG_SETTING` 상수를 읽기 때문

## 해결
```typescript
// After - 실제 저장된 설정을 읽음
display(): void {
    const tagSetting = this.plugin.settings.frontmatter.find((f) => f.id === 0);
    if (!tagSetting) return;

    this.createFrontmatterSetting(this.containerEl, tagSetting, actions, false);
    //                                              ^^^^^^^^^^
    //                                              실제 설정값!
}
```

## 교훈
상수(constant)는 **초기화**할 때만 사용하고, **UI 렌더링**에는 항상 실제 데이터를 사용해야 함.

## Test Results
- Build: ✅ Pass