### PR TITLE
fix: extract magic number to named constant

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -6,6 +6,7 @@ export const COMMON_CONSTANTS = {
 	DEFAULT_RELIABILITY_MIN: 0,
 	DEFAULT_RELIABILITY_MAX: 1,
 	DEFAULT_TEMPERATURE: 0.7,
+	MIN_RELIABILITY_THRESHOLD: 0.2,
 	VERIFY_CONNECTION_SYSTEM_PROMPT: 'You are a test system. You must respond with valid JSON.',
 	VERIFY_CONNECTION_USER_PROMPT: 'Return a JSON object containing {"output": [], "reliability": 0}',
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { processAPIRequest } from 'api';
 import type { TFile } from 'obsidian';
 import { Plugin } from 'obsidian';
 import { CommonNotice } from 'ui/components/common/CommonNotice';
+import { COMMON_CONSTANTS } from './api/constants';
 import { DEFAULT_SYSTEM_ROLE, getPromptTemplate } from './api/prompt';
 import type { ProviderConfig } from './api/types';
 import { getContentWithoutFrontmatter, getTags, insertToFrontMatter } from './frontmatter';
@@ -130,7 +131,7 @@ export default class AutoClassifierPlugin extends Plugin {
 			)
 		);
 
-		if (apiResponse && apiResponse.reliability > 0.2) {
+		if (apiResponse && apiResponse.reliability > COMMON_CONSTANTS.MIN_RELIABILITY_THRESHOLD) {
 			const processFrontMatter = (file: TFile, fn: (frontmatter: any) => void) =>
 				this.app.fileManager.processFrontMatter(file, fn);
 


### PR DESCRIPTION
## Summary
Magic Number를 명명된 상수로 추출

## Magic Number란?
코드에 직접 박힌 숫자로, 그 의미를 알 수 없는 값

```typescript
// Bad - 0.2가 무엇을 의미하는지 알 수 없음
if (apiResponse.reliability > 0.2) {

// Good - 상수명이 의미를 설명함
if (apiResponse.reliability > COMMON_CONSTANTS.MIN_RELIABILITY_THRESHOLD) {
```

## 왜 문제인가?

1. **가독성**: `0.2`만 보면 "이게 뭐지?" 생각해야 함
2. **유지보수**: 나중에 임계값을 바꾸려면 코드 전체에서 `0.2`를 찾아야 함
3. **일관성**: 같은 값이 여러 곳에 있으면 서로 다르게 변경될 위험

## 변경 사항

**`api/constants.ts`**
```typescript
export const COMMON_CONSTANTS = {
    // ...
    MIN_RELIABILITY_THRESHOLD: 0.2,  // ← 추가
};
```

**`main.ts`**
```typescript
// Before
if (apiResponse && apiResponse.reliability > 0.2) {

// After
if (apiResponse && apiResponse.reliability > COMMON_CONSTANTS.MIN_RELIABILITY_THRESHOLD) {
```

## 이점
- 코드를 읽으면 "최소 신뢰도 임계값"임을 바로 알 수 있음
- 임계값 변경 시 한 곳만 수정하면 됨
- IDE에서 상수를 검색하면 사용처를 모두 찾을 수 있음

## Test Results
- Build: ✅ Pass