### PR TITLE
refactor: generalize field value collection with Obsidian API

### DIFF
--- a/src/api/UnifiedProvider.ts
+++ b/src/api/UnifiedProvider.ts
@@ -4,7 +4,7 @@ import {
 	COMMON_CONSTANTS,
 	GEMINI_STRUCTURE_OUTPUT,
 	OLLAMA_STRUCTURE_OUTPUT,
-	OPENAI_STRUCTURE_OUTPUT
+	OPENAI_STRUCTURE_OUTPUT,
 } from './constants';
 import { sendRequest } from './index';
 import type { APIProvider, ProviderConfig, StructuredOutput } from './types';
@@ -21,13 +21,20 @@ const parseJsonResponse = (content: string, providerName: string): StructuredOut
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`Failed to parse ${providerName} response: ${message}. Raw content: ${content.substring(0, 200)}`);
+		throw new Error(
+			`Failed to parse ${providerName} response: ${message}. Raw content: ${content.substring(0, 200)}`
+		);
 	}
 };
 
 interface ProviderSpec {
 	buildHeaders: (apiKey: string) => Record<string, string>;
-	buildRequestBody: (systemRole: string, userPrompt: string, model: string, temperature?: number) => any;
+	buildRequestBody: (
+		systemRole: string,
+		userPrompt: string,
+		model: string,
+		temperature?: number
+	) => any;
 	buildUrl: (baseUrl: string, model: string, apiKey: string) => string;
 	parseResponse: (data: any) => StructuredOutput;
 }
@@ -56,16 +63,18 @@ export class UnifiedProvider implements APIProvider {
 					output: result.input.output,
 					reliability: result.input.reliability,
 				};
-			}
+			},
 		},
 		[PROVIDER_NAMES.GEMINI]: {
 			buildHeaders: () => ({
 				'Content-Type': 'application/json',
 			}),
 			buildRequestBody: (systemRole, userPrompt, _, temperature) => ({
-				contents: [{
-					parts: [{ text: `${systemRole}\n\n${userPrompt}` }],
-				}],
+				contents: [
+					{
+						parts: [{ text: `${systemRole}\n\n${userPrompt}` }],
+					},
+				],
 				generationConfig: {
 					temperature,
 					...GEMINI_STRUCTURE_OUTPUT,
@@ -79,7 +88,7 @@ export class UnifiedProvider implements APIProvider {
 					throw new Error('Gemini response missing content');
 				}
 				return parseJsonResponse(content, 'Gemini');
-			}
+			},
 		},
 		[PROVIDER_NAMES.OLLAMA]: {
 			buildHeaders: (apiKey: string) => {
@@ -108,7 +117,7 @@ export class UnifiedProvider implements APIProvider {
 					throw new Error('Ollama response missing content');
 				}
 				return parseJsonResponse(content, 'Ollama');
-			}
+			},
 		},
 		[PROVIDER_NAMES.OPENROUTER]: {
 			buildHeaders: (apiKey: string) => ({
@@ -132,8 +141,8 @@ export class UnifiedProvider implements APIProvider {
 					throw new Error('OpenRouter response missing content');
 				}
 				return parseJsonResponse(content, 'OpenRouter');
-			}
-		}
+			},
+		},
 	};
 
 	// Default spec for OpenAI, DeepSeek, LMStudio, Custom
@@ -158,7 +167,7 @@ export class UnifiedProvider implements APIProvider {
 				throw new Error('API response missing content');
 			}
 			return parseJsonResponse(content, 'API');
-		}
+		},
 	};
 
 	private getSpec(providerName: string): ProviderSpec {

--- a/src/frontmatter/index.ts
+++ b/src/frontmatter/index.ts
@@ -18,7 +18,14 @@ export const getContentWithoutFrontmatter = (content: string): string => {
 	return content.slice(contentStart);
 };
 
-// Collect all values for a specific frontmatter field from the vault
+/**
+ * Collects all unique values for a specific frontmatter field from the vault.
+ *
+ * @param fieldName - The name of the frontmatter field to collect values for (for example, "tags").
+ * @param files - The list of files to scan for the specified frontmatter field.
+ * @param metadataCache - The Obsidian metadata cache used to access frontmatter and tags.
+ * @returns An array of unique string values found for the specified field across all files.
+ */
 export const getFieldValues = (
 	fieldName: string,
 	files: ReadonlyArray<TFile>,

--- a/src/frontmatter/index.ts
+++ b/src/frontmatter/index.ts
@@ -1,11 +1,11 @@
 import type { MetadataCache, TFile } from 'obsidian';
-import { getAllTags, getFrontMatterInfo } from 'obsidian';
+import { getAllTags, getFrontMatterInfo, parseFrontMatterStringArray } from 'obsidian';
 
 import type {
-        FrontMatter,
-        FrontmatterField,
-        InsertFrontMatterParams,
-        ProcessFrontMatterFn
+	FrontMatter,
+	FrontmatterField,
+	InsertFrontMatterParams,
+	ProcessFrontMatterFn,
 } from './types';
 
 /**
@@ -18,30 +18,35 @@ export const getContentWithoutFrontmatter = (content: string): string => {
 	return content.slice(contentStart);
 };
 
-// Get all tags from the vault
-export const getTags = async (
+// Collect all values for a specific frontmatter field from the vault
+export const getFieldValues = (
+	fieldName: string,
 	files: ReadonlyArray<TFile>,
 	metadataCache: MetadataCache
-): Promise<string[]> => {
-	const allTags = files.reduce((tags, file) => {
+): string[] => {
+	const values = new Set<string>();
+
+	for (const file of files) {
 		const cache = metadataCache.getFileCache(file);
-		if (!cache) return tags;
+		if (!cache) continue;
 
-		const fileTags: string[] | null = getAllTags(cache);
-
-		if (fileTags && fileTags.length > 0) {
-			fileTags.forEach((tag) => tags.add(tag));
+		if (fieldName === 'tags') {
+			// tags requires getAllTags() to include inline tags (#tag in content)
+			// parseFrontMatterStringArray would only get frontmatter tags
+			getAllTags(cache)?.forEach((tag) => values.add(tag));
+		} else {
+			// Delegate to Obsidian API - handles both single values and arrays
+			parseFrontMatterStringArray(cache.frontmatter, fieldName)?.forEach((v) => values.add(v));
 		}
+	}
 
-		return tags;
-	}, new Set<string>());
-	return [...allTags];
+	return [...values];
 };
 
 // Moved from BaseSettingsComponent
 export const getFrontmatterSetting = (
-        id: number,
-        settings: FrontmatterField[]
+	id: number,
+	settings: FrontmatterField[]
 ): FrontmatterField => {
 	const setting = settings?.find((f) => f.id === id);
 	if (!setting) {
@@ -59,7 +64,7 @@ export const insertToFrontMatter = async (
 		const rawValues =
 			params.linkType === 'WikiLink' ? params.value.map((item) => `[[${item}]]`) : params.value;
 
-                const existingRawValues = frontmatter[params.name] || [];
+		const existingRawValues = frontmatter[params.name] || [];
 		// Combine values based on overwrite setting
 		let combinedRawValues = params.overwrite ? rawValues : [...existingRawValues, ...rawValues];
 
@@ -67,6 +72,6 @@ export const insertToFrontMatter = async (
 		combinedRawValues = [...new Set(combinedRawValues)].filter(Boolean);
 
 		// Format back for storage context
-                frontmatter[params.name] = combinedRawValues;
-        });
+		frontmatter[params.name] = combinedRawValues;
+	});
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,11 +69,11 @@ export default class AutoClassifierPlugin extends Plugin {
 		await this.processFrontmatterItem(selectedProvider, currentFile, frontmatter);
 	}
 
-        private readonly processFrontmatterItem = async (
-                selectedProvider: ProviderConfig,
-                currentFile: TFile,
-                frontmatter: FrontmatterField
-        ): Promise<void> => {
+	private readonly processFrontmatterItem = async (
+		selectedProvider: ProviderConfig,
+		currentFile: TFile,
+		frontmatter: FrontmatterField
+	): Promise<void> => {
 		const fileNameWithoutExt = currentFile.name.replace(/\.[^/.]+$/, '');
 		if (frontmatter.name === 'tags') {
 			frontmatter.refs = await getTags(this.app.vault.getMarkdownFiles(), this.app.metadataCache);
@@ -135,13 +135,13 @@ export default class AutoClassifierPlugin extends Plugin {
 			const processFrontMatter = (file: TFile, fn: (frontmatter: any) => void) =>
 				this.app.fileManager.processFrontMatter(file, fn);
 
-                        await insertToFrontMatter(processFrontMatter, {
-                                file: currentFile,
-                                name: frontmatter.name,
-                                value: apiResponse.output,
-                                overwrite: frontmatter.overwrite,
-                                linkType: frontmatter.linkType,
-                        });
+			await insertToFrontMatter(processFrontMatter, {
+				file: currentFile,
+				name: frontmatter.name,
+				value: apiResponse.output,
+				overwrite: frontmatter.overwrite,
+				linkType: frontmatter.linkType,
+			});
 			const successMessage = [
 				`✓ ${fileNameWithoutExt} (${frontmatter.name})`,
 				`Reliability: ${apiResponse.reliability}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { CommonNotice } from 'ui/components/common/CommonNotice';
 import { COMMON_CONSTANTS } from './api/constants';
 import { DEFAULT_SYSTEM_ROLE, getPromptTemplate } from './api/prompt';
 import type { ProviderConfig } from './api/types';
-import { getContentWithoutFrontmatter, getTags, insertToFrontMatter } from './frontmatter';
+import { getContentWithoutFrontmatter, getFieldValues, insertToFrontMatter } from './frontmatter';
 import type { FrontmatterField } from './frontmatter/types';
 import type { AutoClassifierSettings } from './ui';
 import { AutoClassifierSettingTab } from './ui';
@@ -75,8 +75,13 @@ export default class AutoClassifierPlugin extends Plugin {
 		frontmatter: FrontmatterField
 	): Promise<void> => {
 		const fileNameWithoutExt = currentFile.name.replace(/\.[^/.]+$/, '');
-		if (frontmatter.name === 'tags') {
-			frontmatter.refs = await getTags(this.app.vault.getMarkdownFiles(), this.app.metadataCache);
+		// Auto-collect refs from vault if not already set
+		if (!frontmatter.refs || frontmatter.refs.length === 0) {
+			frontmatter.refs = getFieldValues(
+				frontmatter.name,
+				this.app.vault.getMarkdownFiles(),
+				this.app.metadataCache
+			);
 			await this.saveSettings();
 		}
 


### PR DESCRIPTION
## Summary
- Generalize `getTags` → `getFieldValues` to collect values for any frontmatter field, not just tags
- Delegate array handling to Obsidian's `parseFrontMatterStringArray` API for cleaner code
- Auto-collect refs from vault for all frontmatter fields when refs is empty (fixes DRY violation)

## Changes
- `src/frontmatter/index.ts`: Renamed function, uses `parseFrontMatterStringArray` for non-tag fields
- `src/main.ts`: Changed condition from tags-only to all fields when refs empty
- `src/api/UnifiedProvider.ts`: Style formatting only

## Test plan
- [ ] Verify tags field still collects inline tags (`#tag` in content)
- [ ] Verify other frontmatter fields (e.g., `category`, `status`) auto-collect from vault
- [ ] Confirm classification workflow works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)