### PR TITLE
fix: use model ID instead of name for selectedModel

### DIFF
--- a/src/ui/containers/Api.ts
+++ b/src/ui/containers/Api.ts
@@ -129,7 +129,7 @@ export class Api {
 						onChange: async (value) => {
 							if (value) {
 								this.plugin.settings.selectedProvider = provider.name;
-								this.plugin.settings.selectedModel = config.name;
+								this.plugin.settings.selectedModel = config.id;
 								await this.plugin.saveSettings();
 								this.display();
 							}


### PR DESCRIPTION
## Summary
- Fix model selection storing `config.name` instead of `config.id`
- This caused model toggle to not show as active after selection
- This caused API 400 errors due to invalid model identifier being sent

## Root Cause
In `Api.ts` line 132, `selectedModel` was set to `config.name` (display name like "GPT-4o") but all comparisons used `config.id` (API model ID like "gpt-4o").

## Test plan
- [ ] Select a model and verify the toggle shows as active
- [ ] Run classification and verify no 400 error from API
- [ ] Reload Obsidian and verify selected model persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)