### PR TITLE
Make the frontmatter editor folder action icon-first

### DIFF
--- a/src/ui/settings/modals/FrontmatterEditorModal.ts
+++ b/src/ui/settings/modals/FrontmatterEditorModal.ts
@@ -113,8 +113,8 @@ export class ConfigurableSettingModal extends Modal {
 			.setDesc('Values that the AI can use as suggestions')
 			.addButton((button) => {
 				button
-					.setButtonText('Browse files')
 					.setIcon('folder')
+					.setTooltip('Browse files')
 					.onClick(() => {
 						const wikiLinkSelector = new WikiLinkSelector(this.app);
 						wikiLinkSelector.openFileSelector((selectedLink) => {
@@ -125,6 +125,7 @@ export class ConfigurableSettingModal extends Modal {
 							this.updateOptionsTextarea();
 						});
 					});
+				button.buttonEl.setAttribute('aria-label', 'Browse files');
 			});
 
 		if (this.props.options.showTextArea) {


### PR DESCRIPTION
## Summary
- switch the frontmatter editor browse action to an icon-first control
- keep accessible browse text via tooltip and aria label
- preserve the same file selection behavior

## Issue
- Closes #44

## Verification
- `pnpm run ci`